### PR TITLE
Make Cassandra heap size configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,7 @@ options:
       Amount of memory to set to the Cassandra's JVM heap.
       Used for both minimum and maximum heap size (`-Xms` and `-Xmx` respectively).
       Valid values are formed by an integer, followed by one of the following memory units:
-      `k` (Kylobytes), `m` (megabytes), `g` (gigabytes).
+      `k` (Kilobytes), `m` (megabytes), `g` (gigabytes).
       Memory units can also be capitalized as `K`, `M`, `G`.
       Notice that, since the numerical value of the setting must be an integer,
       using `-Xmx512m` is valid, but `-Xmx0.5g` will cause an error.

--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,13 @@ options:
     default: 9042
     description: The port to expose for cql connections
     type: int
+  heap_size:
+    default: 6G
+    description: |
+      Amount of memory to set to the Cassandra's JVM heap.
+      Used for both minimum and maximum heap size (`-Xms` and `-Xmx` respectively).
+      Valid values are formed by an integer, followed by one of the following memory units:
+      `k` (Kylobytes), `m` (megabytes), `g` (gigabytes).
+      Memory units can also be capitalized as `K`, `M`, `G`.
+      Notice that, since the numerical value of the setting must be an integer,
+      using `-Xmx512m` is valid, but `-Xmx0.5g` will cause an error.

--- a/src/charm.py
+++ b/src/charm.py
@@ -422,7 +422,7 @@ class CassandraOperatorCharm(CharmBase):
     def _configure(self, event):
         heap_size = self.model.config["heap_size"]
 
-        if match("^\\d+[kKmMgG]$", heap_size) is None:
+        if match(r"^\d+[KMG]$", heap_size) is None:
             message = f"Invalid Cassandra heap size setting: '{heap_size}'"
             self.unit.status = BlockedStatus(message)
             raise DeferEventError(event, message)

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,7 +47,7 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError
 from ops.pebble import APIError, ConnectionError
 
-from re import match
+from re import IGNORECASE, match
 
 logger = logging.getLogger(__name__)
 
@@ -422,7 +422,7 @@ class CassandraOperatorCharm(CharmBase):
     def _configure(self, event):
         heap_size = self.model.config["heap_size"]
 
-        if match(r"^\d+[KMG]$", heap_size) is None:
+        if match(r"^\d+[KMG]$", heap_size, IGNORECASE) is None:
             message = f"Invalid Cassandra heap size setting: '{heap_size}'"
             self.unit.status = BlockedStatus(message)
             raise DeferEventError(event, message)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -192,3 +192,13 @@ class TestCharm(unittest.TestCase):
             )[0]["static_configs"][0]["targets"],
             ["*:9500"],
         )
+
+    @patch("ops.testing._TestingModelBackend.network_get")
+    @patch("ops.testing._TestingPebbleClient.list_files")
+    def test_heap_size_config_invalid(self, mock_net_get, mock_list_files):
+        self.harness.update_config({"heap_size": "0.5g"})
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.model.BlockedStatus("Invalid Cassandra heap size setting: '0.5g'"),
+        )

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -195,6 +195,28 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.testing._TestingModelBackend.network_get")
     @patch("ops.testing._TestingPebbleClient.list_files")
+    def test_heap_size_default(self, mock_net_get, mock_list_files):
+        cassandra_environment = (
+            self._start_cassandra_and_get_pebble_service().environment
+        )
+
+        self.assertEqual(cassandra_environment["JVM_OPTS"], "-Xms6G -Xmx6G")
+        self.assertEqual(self.harness.model.unit.status, ops.model.ActiveStatus())
+
+    @patch("ops.testing._TestingModelBackend.network_get")
+    @patch("ops.testing._TestingPebbleClient.list_files")
+    def test_heap_size_config_success(self, mock_net_get, mock_list_files):
+        self.harness.update_config({"heap_size": "1g"})
+
+        cassandra_environment = (
+            self._start_cassandra_and_get_pebble_service().environment
+        )
+
+        self.assertEqual(cassandra_environment["JVM_OPTS"], "-Xms1g -Xmx1g")
+        self.assertEqual(self.harness.model.unit.status, ops.model.ActiveStatus())
+
+    @patch("ops.testing._TestingModelBackend.network_get")
+    @patch("ops.testing._TestingPebbleClient.list_files")
     def test_heap_size_config_invalid(self, mock_net_get, mock_list_files):
         self.harness.update_config({"heap_size": "0.5g"})
 
@@ -202,3 +224,11 @@ class TestCharm(unittest.TestCase):
             self.harness.model.unit.status,
             ops.model.BlockedStatus("Invalid Cassandra heap size setting: '0.5g'"),
         )
+
+    def _start_cassandra_and_get_pebble_service(self):
+        container = self.harness.model.unit.get_container("cassandra")
+
+        self.harness.charm.on.cassandra_pebble_ready.emit(container)
+
+        pebble_plan = self.harness.get_container_pebble_plan("cassandra")
+        return pebble_plan.services["cassandra"]


### PR DESCRIPTION
Currently the Cassandra charm will always use the default heap-size hard-coded in the Cassandra startup scripts.

This change introduces the `heap_size` configuration, which accepts a valid JVM memory size, and passes it to the Cassandra bootstrap over the `JVM_OPTS` environment variable.