### PR TITLE
Fix charmcraft build on 1.2.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,3 +6,7 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    build-packages:
+    - git


### PR DESCRIPTION
Ensure that `git` is correctly installed on the build machine on `lxd`