### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     pytest-operator
 setenv =
     PYTHONPATH={toxinidir}/lib:{toxinidir}/src
-whitelist_externals = curl
+allowlist_externals = curl
 commands =
     curl -L https://github.com/instaclustr/cassandra-exporter/releases/download/v0.9.10/cassandra-exporter-agent-0.9.10.jar -o cassandra-exporter-agent.jar
     pytest -v tests/integration


### PR DESCRIPTION
Remove `whitelist_externals` to tidy up our language, the setting is also deprecated in favour of `allowlist_externals`

https://tox.readthedocs.io/en/latest/config.html#conf-allowlist_externals